### PR TITLE
Fix links on "make message" page

### DIFF
--- a/docs/make-message/index.md
+++ b/docs/make-message/index.md
@@ -3,6 +3,6 @@ title: Make Message
 sidebar_position: 3
 ---
 
-+ [Make AuthnRequest](authn-request)
-+ [Make Response](response)
-+ [Make LogoutRequest](logout-request)
++ [Make AuthnRequest](authn-request.md)
++ [Make Response](response.md)
++ [Make LogoutRequest](logout-request.md)


### PR DESCRIPTION
Fix the broken links on this page https://docs.litesaml.com/docs/make-message

(at least this gets the links working in github preview)